### PR TITLE
Correct the Typesense plugin name and examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ java {
 }
 
 group "io.kestra.plugin"
-description 'Plugin typesense for Kestra'
+description 'Plugin Typesense for Kestra'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
@@ -165,8 +165,8 @@ jar {
     manifest {
         attributes(
                 "X-Kestra-Name": project.name,
-                "X-Kestra-Title": "Template",
-                "X-Kestra-Group": project.group + ".templates",
+                "X-Kestra-Title": "Typesense",
+                "X-Kestra-Group": project.group + ".typesense",
                 "X-Kestra-Description": project.description,
                 "X-Kestra-Version": project.version
         )

--- a/src/main/java/io/kestra/plugin/typesense/BulkIndex.java
+++ b/src/main/java/io/kestra/plugin/typesense/BulkIndex.java
@@ -38,20 +38,21 @@ import reactor.core.publisher.Flux;
     examples = {
         @io.kestra.core.models.annotations.Example(
             title = "Index documents to a Typesense DB from an ION file",
+            full = true,
             code = {
                 """
-                    id: typesense
-                    namespace: company.team
+                id: typesense_bulk_index
+                namespace: company.team
 
-                    tasks:
-                    - id: bulk_index
-                      type: io.kestra.plugin.typesense.BulkIndex
-                      apiKey: test-key
-                      port: 8108
-                      host: localhost
-                      collection: Countries
-                      from: file_uri
-                    """
+                tasks:
+                  - id: bulk_index
+                    type: io.kestra.plugin.typesense.BulkIndex
+                    apiKey: "{{ secret('TYPESENSE_API_KEY') }}"
+                    port: 8108
+                    host: localhost
+                    collection: Countries
+                    from: file_uri
+                """
             }
         )
     }

--- a/src/main/java/io/kestra/plugin/typesense/DocumentGet.java
+++ b/src/main/java/io/kestra/plugin/typesense/DocumentGet.java
@@ -28,20 +28,21 @@ import org.typesense.api.Client;
     examples = {
         @io.kestra.core.models.annotations.Example(
             title = "Get a document from a Typesense DB",
+            full = true,
             code = {
                 """
-                    id: typesense
-                    namespace: compnay.team
+                id: typesense_get_document
+                namespace: compnay.team
 
-                    tasks:
-                    - id: get_document
-                      type: io.kestra.plugin.typesense.DocumentGet
-                      documentId: "0"
-                      apiKey: test-key
-                      port: 8108
-                      host: localhost
-                      collection: Countries
-                    """
+                tasks:
+                  - id: get_document
+                    type: io.kestra.plugin.typesense.DocumentGet
+                    documentId: "0"
+                    apiKey: "{{ secret('TYPESENSE_API_KEY') }}"
+                    port: 8108
+                    host: localhost
+                    collection: Countries
+                """
             }
         )
     }

--- a/src/main/java/io/kestra/plugin/typesense/DocumentIndex.java
+++ b/src/main/java/io/kestra/plugin/typesense/DocumentIndex.java
@@ -29,20 +29,21 @@ import org.typesense.api.Client;
     examples = {
         @io.kestra.core.models.annotations.Example(
             title = "Index a document to a Typesense DB",
+            full = true,
             code = {
                 """
-                    id: typesense
-                    namespace: compnay.team
+                id: typesense_index_document
+                namespace: compnay.team
 
-                    tasks:
-                    - id: index_document
-                      type: io.kestra.plugin.typesense.DocumentIndex
-                      document: { "countryName":"France", "capital": "Paris", "gdp": 123456}
-                      apiKey: test-key
-                      port: 8108
-                      host: localhost
-                      collection: Countries
-                    """
+                tasks:
+                  - id: index_document
+                    type: io.kestra.plugin.typesense.DocumentIndex
+                    document: { "countryName":"France", "capital": "Paris", "gdp": 123456}
+                    apiKey: "{{ secret('TYPESENSE_API_KEY') }}"
+                    port: 8108
+                    host: localhost
+                    collection: Countries
+                """
             }
         )
     }

--- a/src/main/java/io/kestra/plugin/typesense/FacetSearch.java
+++ b/src/main/java/io/kestra/plugin/typesense/FacetSearch.java
@@ -26,24 +26,25 @@ import org.typesense.model.SearchParameters;
     examples = {
         @io.kestra.core.models.annotations.Example(
             title = "Search documents with facet",
+            full = true,
             code = {
                 """
-                    id: typesense
-                    namespace: company.team
+                id: typesense_facet_search
+                namespace: company.team
 
-                    tasks:
-                    - id: search
-                      type: io.kestra.plugin.typesense.FacetSearch
-                      apiKey: test-key
-                      port: 8108
-                      host: localhost
-                      collection: Countries
-                      query: Paris
-                      queryBy: capital
-                      filter: countryName: [France, England]
-                      sortBy: gdp:desc
-                      facetBy: gdp
-                    """
+                tasks:
+                  - id: facet_search
+                    type: io.kestra.plugin.typesense.FacetSearch
+                    apiKey: "{{ secret('TYPESENSE_API_KEY') }}"
+                    port: 8108
+                    host: localhost
+                    collection: Countries
+                    query: Paris
+                    queryBy: capital
+                    filter: "countryName: [France, England]"
+                    sortBy: "gdp:desc"
+                    facetBy: gdp
+                """
             }
         )
     }

--- a/src/main/java/io/kestra/plugin/typesense/Search.java
+++ b/src/main/java/io/kestra/plugin/typesense/Search.java
@@ -38,23 +38,24 @@ import reactor.core.publisher.Flux;
     examples = {
         @io.kestra.core.models.annotations.Example(
             title = "Search documents",
+            full = true,
             code = {
                 """
-                    id: typesense
-                    namespace: company.team
+                id: typesense_search
+                namespace: company.team
 
-                    tasks:
-                    - id: search
-                      type: io.kestra.plugin.typesense.Search
-                      apiKey: test-key
-                      port: 8108
-                      host: localhost
-                      collection: Countries
-                      query: Paris
-                      queryBy: capital
-                      filter: countryName: [France, England]
-                      sortBy: gdp:desc
-                    """
+                tasks:
+                  - id: search
+                    type: io.kestra.plugin.typesense.Search
+                    apiKey: "{{ secret('TYPESENSE_API_KEY') }}"
+                    port: 8108
+                    host: localhost
+                    collection: Countries
+                    query: Paris
+                    queryBy: capital
+                    filter: "countryName: [France, England]"
+                    sortBy: "gdp:desc"
+                """
             }
         )
     }


### PR DESCRIPTION
- Corrected the plugin name
- Examples are complete, but `full = true` is missing
- The YAML was incorrect for examples containing `:` in the values
- Corrected the indentation
