### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/typesense/AbstractTypesenseTask.java
+++ b/src/main/java/io/kestra/plugin/typesense/AbstractTypesenseTask.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @AllArgsConstructor
@@ -30,6 +31,7 @@ public abstract class AbstractTypesenseTask extends Task {
         description = "Hostname or IP address of the Typesense cluster node or load balancer"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> host;
 
     @Schema(
@@ -37,6 +39,7 @@ public abstract class AbstractTypesenseTask extends Task {
         description = "TCP port for the Typesense HTTP API; 8108 is the Typesense default"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> port;
 
     @Schema(
@@ -44,6 +47,7 @@ public abstract class AbstractTypesenseTask extends Task {
         description = "Admin or search key used for this request; must allow access to the target collection"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> apiKey;
 
     @Schema(
@@ -51,12 +55,14 @@ public abstract class AbstractTypesenseTask extends Task {
         description = "Name of the Typesense collection; value is rendered before each call"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> collection;
 
     @Schema(
         title = "Use HTTPS",
         description = "Default false (HTTP). Set to true to call Typesense over HTTPS/TLS"
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> https;
 
     protected Client getClient(RunContext context) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/typesense/BulkIndex.java
+++ b/src/main/java/io/kestra/plugin/typesense/BulkIndex.java
@@ -28,6 +28,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -72,6 +73,7 @@ public class BulkIndex extends AbstractTypesenseTask implements RunnableTask<Bul
         description = "kestra:// or other storage URI pointing to an Amazon ION file with one JSON document per line."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> from;
 
     @Schema(
@@ -79,6 +81,7 @@ public class BulkIndex extends AbstractTypesenseTask implements RunnableTask<Bul
         description = "Number of documents per Typesense bulk call. Default 1000; lower to reduce memory, raise to improve throughput."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Integer> chunk = Property.ofValue(1000);
 
     @Override

--- a/src/main/java/io/kestra/plugin/typesense/DocumentGet.java
+++ b/src/main/java/io/kestra/plugin/typesense/DocumentGet.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -58,6 +59,7 @@ public class DocumentGet extends AbstractTypesenseTask implements RunnableTask<D
         description = "Typesense document id to fetch; must exist in the collection."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> documentId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/typesense/DocumentIndex.java
+++ b/src/main/java/io/kestra/plugin/typesense/DocumentIndex.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -57,6 +58,7 @@ public class DocumentIndex extends AbstractTypesenseTask implements RunnableTask
         description = "Map of fields to upsert. Keys must match the collection schema; nested objects are not flattened."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Map<String, Object>> document;
 
     @Override

--- a/src/main/java/io/kestra/plugin/typesense/FacetSearch.java
+++ b/src/main/java/io/kestra/plugin/typesense/FacetSearch.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -58,6 +59,7 @@ public class FacetSearch extends Search {
         description = "Comma-separated list passed to `facet_by` to compute facet counts."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> facetBy;
 
     @Override

--- a/src/main/java/io/kestra/plugin/typesense/Search.java
+++ b/src/main/java/io/kestra/plugin/typesense/Search.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -70,6 +71,7 @@ public class Search extends AbstractTypesenseTask implements RunnableTask<Search
         description = "Free-text query string sent as `q` to Typesense. Required."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> query;
 
     @Schema(
@@ -78,18 +80,21 @@ public class Search extends AbstractTypesenseTask implements RunnableTask<Search
         example = "country, capital"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> queryBy;
 
     @Schema(
         title = "Filter expression",
         description = "Optional `filter_by` clause to pre-filter results."
     )
+    @PluginProperty(group = "processing")
     protected Property<String> filter;
 
     @Schema(
         title = "Sort expression",
         description = "Optional `sort_by` clause. Example: `gdp:desc`."
     )
+    @PluginProperty(group = "processing")
     protected Property<String> sortBy;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712