### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.3.2-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/typesense/BulkIndex.java
+++ b/src/main/java/io/kestra/plugin/typesense/BulkIndex.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.typesense;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -13,6 +12,7 @@ import org.typesense.model.IndexAction;
 
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -28,7 +28,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -93,8 +92,8 @@ public class BulkIndex extends AbstractTypesenseTask implements RunnableTask<Bul
         URI uri = new URI(renderString(from, runContext));
 
         try (
-            BufferedReader inputStream = new BufferedReader(
-                new InputStreamReader(runContext.storage().getFile(uri)), FileSerde.BUFFER_SIZE
+            BufferedInputStream inputStream = new BufferedInputStream(
+                runContext.storage().getFile(uri), FileSerde.BUFFER_SIZE
             );
         ) {
             AtomicLong count = new AtomicLong();

--- a/src/main/java/io/kestra/plugin/typesense/Search.java
+++ b/src/main/java/io/kestra/plugin/typesense/Search.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.typesense;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 
@@ -13,6 +13,7 @@ import org.typesense.model.SearchResult;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -27,7 +28,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -120,7 +120,7 @@ public class Search extends AbstractTypesenseTask implements RunnableTask<Search
     protected static Output generateOutput(RunContext runContext, SearchResult searchResult)
         throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             FileSerde.writeAll(output, Flux.just(searchResult)).blockOptional();
 
             return Output.builder()

--- a/src/test/java/io/kestra/plugin/typesense/typesense/TypesenseContainer.java
+++ b/src/test/java/io/kestra/plugin/typesense/typesense/TypesenseContainer.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.typesense.typesense;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,11 +86,11 @@ public class TypesenseContainer {
 
     protected Map<String, Object> getResults(Output runOutput, StorageInterface storageInterface)
         throws IOException {
-        BufferedReader searchInputStream = new BufferedReader(
-            new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri()))
+        InputStream searchInputStream = new BufferedInputStream(
+            storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri())
         );
         List<Map<String, Object>> resultWrapper = new ArrayList<>();
-        FileSerde.reader(searchInputStream, r -> resultWrapper.add((Map<String, Object>) r));
+        FileSerde.read(searchInputStream, r -> resultWrapper.add((Map<String, Object>) r));
         return resultWrapper.getFirst();
     }
 }


### PR DESCRIPTION
## Summary
- Bump `kestraVersion` from 1.3.13 to 1.3.19
- Replace deprecated Reader/Writer-based `FileSerde` API with InputStream/OutputStream variants in `BulkIndex.java`, `Search.java`, and `TypesenseContainer.java` test helper
- Enables binary ION compatibility (kestra/kestra#3155)

## Test plan
- [x] Build passes (`./gradlew clean build -x test shadowJar`)
- [ ] Run existing integration tests against a Typesense container