### PR TITLE
refactor: rename deprecated retry property maxAttempt to maxAttempts

### DIFF
--- a/src/test/resources/sanity-checks/all_typesense.yaml
+++ b/src/test/resources/sanity-checks/all_typesense.yaml
@@ -32,7 +32,7 @@ tasks:
     retry:
       type: constant
       interval: PT3S
-      maxAttempt: 20
+      maxAttempts: 20
 
   - id: create_collection
     type: io.kestra.plugin.core.http.Request
@@ -55,7 +55,7 @@ tasks:
     retry:
       type: constant
       interval: PT3S
-      maxAttempt: 10
+      maxAttempts: 10
 
   - id: write_documents
     type: io.kestra.plugin.core.storage.Write


### PR DESCRIPTION
Renames the deprecated retry property maxAttempt to maxAttempts